### PR TITLE
Coverage reporting and setup.py fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 dist
+.eggs
+*.egg
+*.egg-info
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
-  - "3.4"    
+  - "3.4"
   - "3.5"
   - "3.5-dev"
 install: "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ python:
   - "3.5"
   - "3.5-dev"
 install: "pip install -r requirements.txt"
-script: nosetests
+script: python setup.py nosetests
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ python:
   - "3.5-dev"
 install: "pip install -r requirements.txt"
 script: nosetests
+after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - "2.6"
   - "2.7"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+DEV
+===
+
+* setup.py now properly indicates all of the depepdencies that are necessary
+  to run its commands (test and nosetests were broken)
+* Updated the manifest so that the test suite and the changelog are
+  included in dists.
+
 0.2.0
 =====
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include CHANGELOG.rst
 include LICENSE
 include README.rst
 include requirements.txt
+include setup.cfg
+include tests.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include CHANGELOG.rst
 include LICENSE
 include README.rst
 include requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ mock==1.3.0; python_version < '3.3' # used for doctests; added to stdlib in 3.3
 nose==1.3.7
 pep8==1.5.7
 testtube==1.0.0
+twine
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Development dependencies:
+coverage==3.7.1; python_version == '3.2'
 coverage==4.0.3; python_version != '3.2'
-coveralls==1.1; python_version != '3.2'
+coveralls==1.1
 flake8==2.5.0
 flake8-quotes==0.1.1
 isort==4.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 # Development dependencies:
+coverage==4.0.3
+coveralls==1.1
 flake8==2.5.0
 flake8-quotes==0.1.1
 isort==4.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,7 @@ coveralls==1.1
 flake8==2.5.0
 flake8-quotes==0.1.1
 isort==4.2.2
+mock==1.3.0; python_version < '3.3' # used for doctests; added to stdlib in 3.3
 nose==1.3.7
 pep8==1.5.7
 testtube==1.0.0
-
-# Required to run doctests in python 2
-mock==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Development dependencies:
-coverage==4.0.3
-coveralls==1.1
+coverage==4.0.3; python_version != '3.2'
+coveralls==1.1; python_version != '3.2'
 flake8==2.5.0
 flake8-quotes==0.1.1
 isort==4.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ ignore-files=tube.py
 
 [coverage:run]
 include=tdubs.py
+
+[wheel]
+universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ with-doctest=1
 doctest-options=+ELLIPSIS,+IGNORE_EXCEPTION_DETAIL
 doctest-extension=rst
 with-coverage=1
+ignore-files=tube.py
 
 [coverage:run]
 include=tdubs.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,7 @@
 with-doctest=1
 doctest-options=+ELLIPSIS,+IGNORE_EXCEPTION_DETAIL
 doctest-extension=rst
+with-coverage=1
+
+[coverage:run]
+include=tdubs.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ with-doctest=1
 doctest-options=+ELLIPSIS,+IGNORE_EXCEPTION_DETAIL
 doctest-extension=rst
 with-coverage=1
-ignore-files=tube.py
+ignore-files=(?:^\.|^_,|^setup\.py$|^tube\.py$)
 cover-package=tdubs
 
 [wheel]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,7 @@ doctest-options=+ELLIPSIS,+IGNORE_EXCEPTION_DETAIL
 doctest-extension=rst
 with-coverage=1
 ignore-files=tube.py
-
-[coverage:run]
-include=tdubs.py
+cover-package=tdubs
 
 [wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,17 @@
 from setuptools import setup
+import sys
 
+# We need the following dependenices so that setup.py's command nosetests will
+# run correclty without manually installing all dev dependencies. Note that
+# these requirements cannot be specified as setup's tests_require param
+# because tests_require dependencies are not installed before attempting to
+# execute nosetests. nosetests is necessary because python setup.py test
+# will not capture doctests.
+setup_requires = ['nose==1.3.7', 'coverage==4.0.3']
+
+# mock is needed for doctests; it wasn't added to stdlib until python 3.3
+if sys.version_info[:2] < (3, 3):
+    setup_requires += ['mock==1.3.0']
 
 setup(
     name='tdubs',
@@ -9,6 +21,7 @@ setup(
     author_email='justin@blaix.com',
     description='A test double library',
     py_modules=['tdubs'],
+    setup_requires=setup_requires,
     license='MIT (Expat)',
     classifiers=[
         'Intended Audience :: Developers',
@@ -24,4 +37,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Testing',
     ],
+    # The following allows the test command to find and execute unit tests
+    # but not any of the doc tests. Use the nosetests command to run the full
+    # test suite.
+    test_suite='nose.collector'
 )

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ if sys.version_info[:2] < (3, 3):
 # coverage doesn't support python 3.2. Coverage reporting will fail in 3.2
 if sys.version_info[:2] == (3, 2):
     setup_requires.remove('coverage==4.0.3')
+    setup_requires += ['coverage==3.7.1']
 
 setup(
     name='tdubs',

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,10 @@ setup_requires = ['nose==1.3.7', 'coverage==4.0.3']
 if sys.version_info[:2] < (3, 3):
     setup_requires += ['mock==1.3.0']
 
+# coverage doesn't support python 3.2. Coverage reporting will fail in 3.2
+if sys.version_info[:2] == (3, 2):
+    setup_requires.remove('coverage==4.0.3')
+
 setup(
     name='tdubs',
     version='0.2.0',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import multiprocessing  # noqa `python setup.py test` fix for python 2.6
 from setuptools import setup
 import sys
 


### PR DESCRIPTION
I initially wanted to just add coverage reporting, but I ended up needing to take care of a number of additional setup.py changes to support of that. This pull:
1. Configures coverage reporting and readies the repo for https://coveralls.io/
2. Fixes setup.py so that all of its commands work correctly without manually installing things from requirements.txt
3. Installs and configures dependencies to make building signed universal wheel dists reasonable (https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/)
4. Reconfigures travis so that it executes the test suite via setup.py for added verification. Note that it still uses pip to install requirements in that environment so that we can take advantage of build dependency caching.
